### PR TITLE
Implement confirm modals

### DIFF
--- a/src/components/App/App.module.scss
+++ b/src/components/App/App.module.scss
@@ -23,10 +23,19 @@
   margin-right: 8px;
   font-size: 14px;
 
-  &:hover {
-    background-color: orange;
-    color: black;
+  @media (hover: hover) {
+    &:hover {
+      color: #ffa500;
+    }
   }
+
+  &:active {
+    background-color: #ffa500;
+  }
+}
+
+.controls {
+  display: flex;
 }
 
 .buttonRow {
@@ -62,9 +71,10 @@
   .input {
     font-size: 14px;
   }
+}
 
-  .noclick {
-    pointer-events: none;
-    cursor: none;
-  }
+.noclick {
+  pointer-events: none;
+  cursor: none;
+  overflow: hidden;
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames'
 import opentype from 'opentype.js'
-import {useReducer, useState} from 'react'
+import {useReducer} from 'react'
 import Modal from 'react-modal'
 import {useMediaQuery} from 'react-responsive'
 import styles from './App.module.scss'
@@ -10,7 +10,6 @@ import {
   DEFAULT_PROMPT,
   EXPORT_ALERT,
   EXPORT_PROMPT,
-  LOAD_WARNING,
   MOBILE_HELP,
   RESET_ALERT,
   SUBMIT_ALERT,
@@ -32,13 +31,6 @@ const XS_SCREEN = 576
 const App = ({bitmapSize}: {bitmapSize: number}) => {
   Modal.setAppElement('#root')
   const screenFlag = useMediaQuery({query: `(max-width: ${XS_SCREEN}px)`})
-
-  const [loadFlag, setLoadFlag] = useState(false)
-
-  if (screenFlag && !loadFlag) {
-    alert(LOAD_WARNING)
-    setLoadFlag(true)
-  }
 
   const canvasSize = screenFlag ? Math.floor(window.innerWidth / 32) * 32 : 512
   const glyphSize = 48

--- a/src/components/ConfirmModal/ConfirmModal.module.scss
+++ b/src/components/ConfirmModal/ConfirmModal.module.scss
@@ -1,0 +1,40 @@
+.overlay {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(128, 125, 125, 0.95);
+  color: white;
+  z-index: 9999;
+  width: 600px;
+}
+
+.modal {
+  outline: none;
+  margin: auto;
+  border-radius: 2px;
+  padding: 10px 20px;
+}
+
+.button {
+  font-family: ChicagoFLF;
+  width: 90px;
+  background-color: rgba(255, 255, 255, 0.87);
+  color: black;
+  border-radius: 2px;
+  height: 28px;
+  margin-right: 8px;
+  font-size: 14px;
+  text-align: center;
+
+  &:hover {
+    background-color: orange;
+    color: black;
+  }
+}
+
+@media screen and (max-width: 576px) {
+  .overlay {
+    width: 400px;
+  }
+}

--- a/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import Modal from 'react-modal'
+import styles from './ConfirmModal.module.scss'
+import {TConfirmModal, TFontProps} from '../../types'
+
+type TConfirmModalProps = TFontProps & {
+  type: TConfirmModal
+  onConfirm?: () => void
+  message: string
+  cancelFlag?: boolean
+}
+
+const ConfirmModal: React.FC<TConfirmModalProps> = ({
+  fontState,
+  fontDispatch,
+  type,
+  onConfirm = () => void 0,
+  message,
+  cancelFlag = true,
+}) => {
+  const {confirmModal} = fontState
+
+  const onRequestClose = () =>
+    fontDispatch({
+      type: 'GLYPH_SET_ACTION',
+      op: 'UPDATE_CONFIRM_MODAL',
+      newConfirmModal: undefined,
+    })
+
+  return (
+    <Modal
+      className={styles.modal}
+      overlayClassName={styles.overlay}
+      isOpen={confirmModal === type}
+    >
+      <p>{message}</p>
+      <button
+        className={styles.button}
+        onClick={() => {
+          onConfirm()
+          onRequestClose()
+        }}
+      >
+        Confirm
+      </button>
+      {cancelFlag && (
+        <button className={styles.button} onClick={onRequestClose}>
+          Cancel
+        </button>
+      )}
+    </Modal>
+  )
+}
+
+export default ConfirmModal

--- a/src/components/GlyphSet/GlyphSet.module.scss
+++ b/src/components/GlyphSet/GlyphSet.module.scss
@@ -4,17 +4,25 @@
   width: 450px;
 }
 
-.modal {
+.overlay {
+  width: 100%;
+  position: fixed;
   display: flex;
   flex-flow: column wrap;
   justify-content: flex-start;
+  align-items: center;
+  background-color: rgba(128, 125, 125, 1);
+  z-index: 9999;
+}
+
+.modal {
   position: fixed;
   z-index: 9999;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(128, 125, 125, 0.8);
+  background: rgba(128, 125, 125, 1);
   color: white;
   outline: none;
   text-align: center;

--- a/src/components/GlyphSet/GlyphSet.tsx
+++ b/src/components/GlyphSet/GlyphSet.tsx
@@ -17,7 +17,7 @@ const GlyphSet: React.FC<TFontProps> = ({fontState, fontDispatch}) => {
     <Modal
       isOpen={glyphSetModal}
       className={styles.modal}
-      overlayClassName={styles.modal}
+      overlayClassName={styles.overlay}
     >
       <h2>GALLERY</h2>
       <Gallery fontState={fontState} fontDispatch={fontDispatch} />

--- a/src/index.css
+++ b/src/index.css
@@ -23,7 +23,6 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
-  overflow: auto;
 }
 
 a {
@@ -50,12 +49,13 @@ h1 {
 }
 
 @media screen and (max-width: 576px) {
-  :root {
-    overflow: hidden;
+  body {
+    min-height: 0;
   }
+
   h1 {
     font-family: Karektar;
-    font-size: 3em;
+    font-size: 42px;
     margin-bottom: 10px;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export type TOption = {
 }
 export type TButtonType = TTool | TAction | TOption
 
+export type TConfirmModal = 'SUBMIT' | 'RESET' | 'EXPORT' | 'HELP'
+
 export type TMenuLabel = 'SHAPES' | 'OPTIONS'
 export type TMenuHeader = {
   defaultLabel: TMenuLabel
@@ -43,6 +45,7 @@ export type TFont = {
   canvasHistory: boolean[][]
   canvasSize: number
   captureFlag: boolean
+  confirmModal: TConfirmModal | undefined
   currentTool: TToolLabel
   galleryPage: number
   glyphSet: TGlyphSet
@@ -75,6 +78,7 @@ export type TCanvasAction = {type: 'CANVAS_ACTION'} & (
 export type TGlyphSetAction = {type: 'GLYPH_SET_ACTION'} & (
   | {op: 'RESET_GLYPH_SET'}
   | {op: 'UPDATE_ACTIVE_GLYPH'; newActiveGlyph: string}
+  | {op: 'UPDATE_CONFIRM_MODAL'; newConfirmModal: TConfirmModal | undefined}
   | {op: 'UPDATE_GALLERY_PAGE'; newGalleryPage: number}
   | {op: 'UPDATE_GLYPH_CANVAS'; newGlyphCanvas: boolean[]}
   | {op: 'UPDATE_GLYPH_SIZE'; newGlyphSize: number}

--- a/src/utils/constants/app.constants.ts
+++ b/src/utils/constants/app.constants.ts
@@ -21,8 +21,4 @@ export const RX_NUMBERS = /[0-9]/g
 export const SUBMIT_ALERT =
   'You are about to remove some of the existing glyphs in your set. Are you sure you want to continue?'
 export const WIKI_LINK = 'https://en.wikipedia.org/wiki/Susan_Kare'
-export const LOAD_WARNING =
-  'The mobile version of Karektar is still work-in-progress! Be especially careful when ' +
-  'using the Reset button on the iOS Firefox app (below v117), as the confirm dialog does ' +
-  'not always work properly, and may reset prematurely. Enjoy!'
 export const UNITS_PER_EM = 1024

--- a/src/utils/constants/app.constants.ts
+++ b/src/utils/constants/app.constants.ts
@@ -11,8 +11,6 @@ export const EXPORT_ALERT =
   'You are about to export with empty glyphs in your glyph set. Are you sure you want to continue?'
 export const EXPORT_PROMPT =
   'Enter your font family name and style name, separated by space. (Default style is "Regular".)'
-export const MOBILE_HELP =
-  '\n(Tap the glyph icon on the top left to view the gallery.)'
 export const RESET_ALERT =
   'You are about to reset all progress from your glyph set. Are you sure you want to continue?'
 export const RX_LETTERS = /[A-Za-z]/g
@@ -22,3 +20,16 @@ export const SUBMIT_ALERT =
   'You are about to remove some of the existing glyphs in your set. Are you sure you want to continue?'
 export const WIKI_LINK = 'https://en.wikipedia.org/wiki/Susan_Kare'
 export const UNITS_PER_EM = 1024
+
+export const HELP_MESSAGE =
+  'Edit the input field and click "Submit" to generate your own glyphset. Drag across ' +
+  'the canvas to draw, or perform other operations by selecting one of the given tools. ' +
+  "Use the gallery on the right to change to editing other glyphs. When you're done, " +
+  'click "Export" to save your work to an OTF file!'
+
+export const MOBILE_HELP_MESSAGE =
+  'Edit the input field and click "Submit" to generate your own glyphset. Drag across ' +
+  'the canvas to draw, or tap on the pencil icon to select another tool. You can also ' +
+  'tap on the icon of the current glyph on the top right to view the gallery, where you ' +
+  "can switch to editing other glyphs. When you're done, " +
+  'click "Export" to save your work to an OTF file!'

--- a/src/utils/helpers/app.helpers.ts
+++ b/src/utils/helpers/app.helpers.ts
@@ -47,6 +47,7 @@ export const initializeFont = (
     canvasHistory: [initializeGlyph(bitmapSize)],
     canvasSize: canvasSize,
     captureFlag: false,
+    confirmModal: undefined,
     currentTool: 'DRAW',
     galleryPage: 0,
     glyphSet: newGlyphSet,

--- a/src/utils/reducers/fontReducer.ts
+++ b/src/utils/reducers/fontReducer.ts
@@ -37,6 +37,9 @@ export const glyphSetReducer = (state: TFont, action: TGlyphSetAction): TFont =>
         historyIndex: 0,
       }
     }
+    case 'UPDATE_CONFIRM_MODAL': {
+      return {...state, confirmModal: action.newConfirmModal}
+    }
     case 'UPDATE_GALLERY_PAGE': {
       return {...state, galleryPage: action.newGalleryPage}
     }


### PR DESCRIPTION
This PR implements a custom "confirm modal" component, to replace the default JS confirm dialogs that (conditionally) show up when performing submit/reset/export operations. In addition, a basic help dialog was included to briefly give an overview of how to interact with the application.