### PR TITLE
Add Google OAuth session auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+.dev.vars
+.wrangler
 
 # Editor directories and files
 .vscode/*

--- a/functions/api/auth/callback.ts
+++ b/functions/api/auth/callback.ts
@@ -1,0 +1,115 @@
+import {
+  buildSessionCookie,
+  CONTENT_TYPE,
+  GOOGLE_TOKEN_URL,
+  GOOGLE_USERINFO_URL,
+  HTTP_STATUS,
+  OAUTH_STATE_PREFIX,
+  SESSION_EXPIRY_DAYS,
+  SESSION_EXPIRY_MS,
+  SESSION_PREFIX,
+} from '../../constants'
+import type {
+  GoogleUserInfo,
+  OAuthState,
+  PagesFunctionContext,
+  Session,
+  TokenResponse,
+} from '../../types'
+import {decodeBase64Url} from '../../utils/base64url'
+import {getValidatedUiOrigin} from '../../utils/origin'
+
+export const onRequest = async ({request, env}: PagesFunctionContext) => {
+  try {
+    const url = new URL(request.url)
+    const code = url.searchParams.get('code')
+    const rawState = url.searchParams.get('state')
+
+    if (!code || !rawState) {
+      throw new Error('Missing required parameters')
+    }
+
+    const decodedState = JSON.parse(decodeBase64Url(rawState)) as OAuthState
+    const uiOrigin = getValidatedUiOrigin(decodedState.uiOrigin)
+
+    if (!uiOrigin) {
+      throw new Error('Invalid state parameter')
+    }
+
+    const storedState = await env.MY_KV.get(
+      `${OAUTH_STATE_PREFIX}${decodedState.stateToken}`,
+    )
+
+    if (!storedState || storedState !== rawState) {
+      throw new Error('Invalid state parameter')
+    }
+
+    await env.MY_KV.delete(`${OAUTH_STATE_PREFIX}${decodedState.stateToken}`)
+
+    const tokenResponse = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: new URLSearchParams({
+        code,
+        client_id: env.GOOGLE_CLIENT_ID,
+        client_secret: env.GOOGLE_CLIENT_SECRET,
+        redirect_uri: `${uiOrigin}/api/auth/callback`,
+        grant_type: 'authorization_code',
+      }),
+    })
+
+    if (!tokenResponse.ok) {
+      throw new Error(await tokenResponse.text())
+    }
+
+    const tokens = (await tokenResponse.json()) as TokenResponse
+
+    const userInfoResponse = await fetch(GOOGLE_USERINFO_URL, {
+      headers: {
+        Authorization: `Bearer ${tokens['access_token']}`,
+      },
+    })
+
+    if (!userInfoResponse.ok) {
+      throw new Error('Failed to fetch user info')
+    }
+
+    const user = (await userInfoResponse.json()) as GoogleUserInfo
+
+    if (!user.sub || !user.email || !user.name || !user['email_verified']) {
+      throw new Error('Email not verified')
+    }
+
+    const sessionId = crypto.randomUUID()
+    const session: Session = {
+      userId: user.sub,
+      email: user.email,
+      name: user.name,
+      expiresAt: Date.now() + SESSION_EXPIRY_MS,
+    }
+
+    await env.MY_KV.put(`${SESSION_PREFIX}${sessionId}`, JSON.stringify(session), {
+      expirationTtl: SESSION_EXPIRY_DAYS * 24 * 60 * 60,
+    })
+
+    return new Response(null, {
+      status: HTTP_STATUS.FOUND,
+      headers: {
+        'Cache-Control': 'no-store',
+        Location: uiOrigin,
+        'Set-Cookie': buildSessionCookie(sessionId),
+      },
+    })
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: HTTP_STATUS.BAD_REQUEST,
+        headers: {'Content-Type': CONTENT_TYPE.JSON},
+      },
+    )
+  }
+}

--- a/functions/api/auth/check.ts
+++ b/functions/api/auth/check.ts
@@ -1,0 +1,21 @@
+import {CONTENT_TYPE, HTTP_STATUS, RESPONSE_MESSAGES} from '../../constants'
+import type {PagesFunctionContext} from '../../types'
+import {authenticateRequest} from '../../utils/session'
+
+export const onRequest = async ({request, env}: PagesFunctionContext) => {
+  const session = await authenticateRequest(request, env)
+
+  if (!session) {
+    return new Response(
+      JSON.stringify({error: RESPONSE_MESSAGES.NOT_AUTHENTICATED}),
+      {
+        status: HTTP_STATUS.UNAUTHORIZED,
+        headers: {'Content-Type': CONTENT_TYPE.JSON},
+      },
+    )
+  }
+
+  return new Response(JSON.stringify({email: session.email, name: session.name}), {
+    headers: {'Content-Type': CONTENT_TYPE.JSON},
+  })
+}

--- a/functions/api/auth/google.ts
+++ b/functions/api/auth/google.ts
@@ -1,0 +1,42 @@
+import {
+  GOOGLE_AUTH_URL,
+  HTTP_STATUS,
+  OAUTH_STATE_PREFIX,
+  OAUTH_STATE_TTL_SECONDS,
+} from '../../constants'
+import type {PagesFunctionContext} from '../../types'
+import {encodeBase64Url} from '../../utils/base64url'
+import {getValidatedUiOrigin} from '../../utils/origin'
+
+export const onRequest = async ({request, env}: PagesFunctionContext) => {
+  const url = new URL(request.url)
+  const uiOrigin = getValidatedUiOrigin(url.searchParams.get('uiOrigin'))
+
+  if (!uiOrigin) {
+    return new Response('Invalid uiOrigin parameter', {
+      status: HTTP_STATUS.BAD_REQUEST,
+    })
+  }
+
+  const stateToken = crypto.randomUUID()
+  const state = encodeBase64Url(JSON.stringify({uiOrigin, stateToken}))
+
+  await env.MY_KV.put(`${OAUTH_STATE_PREFIX}${stateToken}`, state, {
+    expirationTtl: OAUTH_STATE_TTL_SECONDS,
+  })
+
+  const authUrl = new URL(GOOGLE_AUTH_URL)
+  authUrl.searchParams.set('client_id', env.GOOGLE_CLIENT_ID)
+  authUrl.searchParams.set('redirect_uri', `${uiOrigin}/api/auth/callback`)
+  authUrl.searchParams.set('response_type', 'code')
+  authUrl.searchParams.set('scope', 'email profile')
+  authUrl.searchParams.set('state', state)
+
+  return new Response(null, {
+    status: HTTP_STATUS.FOUND,
+    headers: {
+      'Cache-Control': 'no-store',
+      Location: authUrl.toString(),
+    },
+  })
+}

--- a/functions/api/auth/logout.ts
+++ b/functions/api/auth/logout.ts
@@ -1,0 +1,34 @@
+import {
+  buildExpiredSessionCookie,
+  CONTENT_TYPE,
+  HTTP_STATUS,
+  RESPONSE_MESSAGES,
+  SESSION_PREFIX,
+} from '../../constants'
+import type {PagesFunctionContext} from '../../types'
+import {getSessionId} from '../../utils/session'
+
+export const onRequest = async ({request, env}: PagesFunctionContext) => {
+  if (request.method !== 'POST') {
+    return new Response(
+      JSON.stringify({error: RESPONSE_MESSAGES.METHOD_NOT_ALLOWED}),
+      {
+        status: HTTP_STATUS.METHOD_NOT_ALLOWED,
+        headers: {'Content-Type': CONTENT_TYPE.JSON},
+      },
+    )
+  }
+
+  const sessionId = getSessionId(request)
+
+  if (sessionId) {
+    await env.MY_KV.delete(`${SESSION_PREFIX}${sessionId}`)
+  }
+
+  return new Response(JSON.stringify({success: true}), {
+    headers: {
+      'Content-Type': CONTENT_TYPE.JSON,
+      'Set-Cookie': buildExpiredSessionCookie(),
+    },
+  })
+}

--- a/functions/constants.ts
+++ b/functions/constants.ts
@@ -1,0 +1,56 @@
+export const STATIC_ALLOWED_ORIGINS = new Set([
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+  'http://localhost:8788',
+  'http://127.0.0.1:8788',
+  'https://karektar.pages.dev',
+  'https://karektar.newtrino.ink',
+])
+
+export const HTTP_STATUS = {
+  FOUND: 302,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  METHOD_NOT_ALLOWED: 405,
+} as const
+
+export const CONTENT_TYPE = {
+  JSON: 'application/json',
+} as const
+
+export const RESPONSE_MESSAGES = {
+  METHOD_NOT_ALLOWED: 'Method not allowed',
+  NOT_AUTHENTICATED: 'Not authenticated',
+} as const
+
+export const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+export const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+export const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'
+
+export const OAUTH_STATE_PREFIX = 'oauth_state:'
+export const SESSION_PREFIX = 'session:'
+
+export const OAUTH_STATE_TTL_SECONDS = 60 * 5
+export const SESSION_EXPIRY_DAYS = 7
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * SESSION_EXPIRY_DAYS
+export const SESSION_EXPIRY_MS = SESSION_MAX_AGE_SECONDS * 1000
+
+export const buildSessionCookie = (sessionId: string) =>
+  [
+    `session=${sessionId}`,
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    'Path=/',
+    `Max-Age=${SESSION_MAX_AGE_SECONDS}`,
+  ].join('; ')
+
+export const buildExpiredSessionCookie = () =>
+  [
+    'session=',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    'Path=/',
+    'Max-Age=0',
+  ].join('; ')

--- a/functions/types.ts
+++ b/functions/types.ts
@@ -1,0 +1,48 @@
+export type Session = {
+  userId: string
+  email: string
+  name: string
+  expiresAt: number
+}
+
+type JsonKvValue = string | ArrayBuffer | ArrayBufferView | ReadableStream
+
+type KvPutOptions = {
+  expirationTtl?: number
+}
+
+export type KVNamespace = {
+  get<TValue = string>(
+    key: string,
+    type?: 'text' | 'json' | 'arrayBuffer' | 'stream',
+  ): Promise<TValue | null>
+  put(key: string, value: JsonKvValue, options?: KvPutOptions): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+export type Env = {
+  MY_KV: KVNamespace
+  GOOGLE_CLIENT_ID: string
+  GOOGLE_CLIENT_SECRET: string
+}
+
+export type PagesFunctionContext = {
+  request: Request
+  env: Env
+}
+
+export type TokenResponse = Record<'access_token', string>
+
+type GoogleUserInfoBase = {
+  sub: string
+  email: string
+  name: string
+}
+
+export type GoogleUserInfo = GoogleUserInfoBase &
+  Partial<Record<'email_verified', boolean>>
+
+export type OAuthState = {
+  uiOrigin: string
+  stateToken: string
+}

--- a/functions/utils/base64url.ts
+++ b/functions/utils/base64url.ts
@@ -1,0 +1,12 @@
+export const encodeBase64Url = (input: string) =>
+  btoa(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+export const decodeBase64Url = (input: string) => {
+  const base64 = input.replace(/-/g, '+').replace(/_/g, '/')
+  const paddedBase64 = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    '=',
+  )
+
+  return atob(paddedBase64)
+}

--- a/functions/utils/origin.ts
+++ b/functions/utils/origin.ts
@@ -1,0 +1,37 @@
+import {STATIC_ALLOWED_ORIGINS} from '../constants'
+
+const PREVIEW_REGEX = /^https:\/\/[^.]+\.karektar\.pages\.dev$/
+
+const normalizeOrigin = (value: string | null) => {
+  if (!value) {
+    return null
+  }
+
+  try {
+    return new URL(value).origin
+  } catch {
+    return null
+  }
+}
+
+export const isAllowedOrigin = (origin: string) => {
+  if (STATIC_ALLOWED_ORIGINS.has(origin)) {
+    return true
+  }
+
+  if (PREVIEW_REGEX.test(origin)) {
+    return true
+  }
+
+  return origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:')
+}
+
+export const getValidatedUiOrigin = (value: string | null) => {
+  const origin = normalizeOrigin(value)
+
+  if (!origin || !isAllowedOrigin(origin)) {
+    return null
+  }
+
+  return origin
+}

--- a/functions/utils/session.ts
+++ b/functions/utils/session.ts
@@ -1,0 +1,35 @@
+import {SESSION_PREFIX} from '../constants'
+import type {Env, Session} from '../types'
+
+const SESSION_COOKIE_REGEX = /(?:^|;\s*)session=([^;]+)/
+
+export const getSessionId = (request: Request) => {
+  const cookieHeader = request.headers.get('Cookie') ?? ''
+  const match = cookieHeader.match(SESSION_COOKIE_REGEX)
+
+  return match ? match[1] : null
+}
+
+export const authenticateRequest = async (
+  request: Request,
+  env: Env,
+): Promise<Session | null> => {
+  const sessionId = getSessionId(request)
+
+  if (!sessionId) {
+    return null
+  }
+
+  const session = await env.MY_KV.get<Session>(`${SESSION_PREFIX}${sessionId}`, 'json')
+
+  if (!session) {
+    return null
+  }
+
+  if (session.expiresAt < Date.now()) {
+    await env.MY_KV.delete(`${SESSION_PREFIX}${sessionId}`)
+    return null
+  }
+
+  return session
+}

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:auth": "npm run build && npx wrangler pages dev dist --port 8788 --kv MY_KV",
     "predeploy": "yarn run build",
     "deploy": "gh-pages -d dist",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint 'src/**/*.{js,jsx,ts,tsx,json}'",
-    "lint:fix": "eslint --fix 'src/**/*.{js,jsx,ts,tsx,json}'",
-    "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc.json"
+    "lint": "eslint '{src,functions}/**/*.{js,jsx,ts,tsx,json}'",
+    "lint:fix": "eslint --fix '{src,functions}/**/*.{js,jsx,ts,tsx,json}'",
+    "format": "prettier --write '{src,functions}/**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc.json"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.0",

--- a/src/components/App/App.module.scss
+++ b/src/components/App/App.module.scss
@@ -1,3 +1,36 @@
+.headerRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.accountMenu {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: flex-end;
+  gap: 6px;
+  margin-top: 12px;
+  max-width: 360px;
+}
+
+.accountText,
+.accountError {
+  margin: 0;
+  font-size: 13px;
+  text-align: right;
+}
+
+.accountError {
+  color: #a32626;
+}
+
+.accountButton {
+  min-width: 84px;
+  width: auto;
+  padding: 0 12px;
+}
+
 .appRow {
   display: flex;
   flex-flow: row nowrap;
@@ -60,6 +93,22 @@
 }
 
 @media screen and (max-width: 576px) {
+  .headerRow {
+    flex-flow: column nowrap;
+    gap: 12px;
+  }
+
+  .accountMenu {
+    align-items: flex-start;
+    margin-top: 0;
+    max-width: 100%;
+  }
+
+  .accountText,
+  .accountError {
+    text-align: left;
+  }
+
   .appRow {
     display: flex;
     flex-flow: row wrap;

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -5,6 +5,12 @@ import Modal from 'react-modal'
 import {useMediaQuery} from 'react-responsive'
 import styles from './App.module.scss'
 import {ReactComponent as GitHub} from '../../assets/github.svg'
+import {
+  AuthUser,
+  beginGoogleLogin,
+  checkAuth,
+  logout as logoutAuth,
+} from '../../services/auth'
 import {TConfirmModal, TFontProps} from '../../types'
 import {
   DEFAULT_FONT_NAME,
@@ -59,6 +65,53 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
   const {confirmModal, glyphSetModal} = fontState
 
   const pageSize = useWindowSize()
+  const [authUser, setAuthUser] = useState<AuthUser | null>(null)
+  const [authLoading, setAuthLoading] = useState(true)
+  const [authError, setAuthError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const loadSession = async () => {
+      try {
+        const user = await checkAuth()
+
+        if (!cancelled) {
+          setAuthUser(user)
+          setAuthError(null)
+        }
+      } catch {
+        if (!cancelled) {
+          setAuthUser(null)
+          setAuthError(null)
+        }
+      } finally {
+        if (!cancelled) {
+          setAuthLoading(false)
+        }
+      }
+    }
+
+    void loadSession()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleLogout = async () => {
+    setAuthLoading(true)
+    setAuthError(null)
+
+    try {
+      await logoutAuth()
+      setAuthUser(null)
+    } catch {
+      setAuthError('Logout failed')
+    } finally {
+      setAuthLoading(false)
+    }
+  }
 
   return (
     <div
@@ -71,7 +124,16 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
       }}
     >
       <div>
-        <Title />
+        <div className={styles.headerRow}>
+          <Title />
+          <AccountMenu
+            authError={authError}
+            authLoading={authLoading}
+            user={authUser}
+            onLogin={beginGoogleLogin}
+            onLogout={handleLogout}
+          />
+        </div>
         {!screenFlag && (
           <>
             <InputField {...fontProps} />
@@ -116,7 +178,7 @@ const useWindowSize = () => {
 
   useEffect(() => {
     window.addEventListener('resize', onResize)
-    return window.removeEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
   }, [])
 
   return size
@@ -129,6 +191,50 @@ const Title = () => (
     </a>
     ktar.
   </h1>
+)
+
+type AccountMenuProps = {
+  authError: string | null
+  authLoading: boolean
+  user: AuthUser | null
+  onLogin: () => void
+  onLogout: () => Promise<void>
+}
+
+const AccountMenu: React.FC<AccountMenuProps> = ({
+  authError,
+  authLoading,
+  user,
+  onLogin,
+  onLogout,
+}) => (
+  <div className={styles.accountMenu}>
+    <p className={styles.accountText}>
+      {authLoading
+        ? 'Checking session...'
+        : user
+          ? `${user.name} (${user.email})`
+          : 'Local draft mode'}
+    </p>
+    {authError && <p className={styles.accountError}>{authError}</p>}
+    {user ? (
+      <button
+        className={styles.accountButton}
+        disabled={authLoading}
+        onClick={() => void onLogout()}
+      >
+        Logout
+      </button>
+    ) : (
+      <button
+        className={styles.accountButton}
+        disabled={authLoading}
+        onClick={onLogin}
+      >
+        Sign In
+      </button>
+    )}
+  </div>
 )
 
 const InputField: React.FC<TFontProps> = ({fontState, fontDispatch}) => {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,37 @@
+export type AuthUser = {
+  email: string
+  name: string
+}
+
+export const checkAuth = async () => {
+  const response = await fetch('/api/auth/check', {
+    credentials: 'include',
+  })
+
+  if (response.status === 401) {
+    return null
+  }
+
+  if (!response.ok) {
+    throw new Error('Failed to check session')
+  }
+
+  return (await response.json()) as AuthUser
+}
+
+export const beginGoogleLogin = () => {
+  const loginUrl = new URL('/api/auth/google', window.location.origin)
+  loginUrl.searchParams.set('uiOrigin', window.location.origin)
+  window.location.href = loginUrl.toString()
+}
+
+export const logout = async () => {
+  const response = await fetch('/api/auth/logout', {
+    method: 'POST',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to log out')
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "useDefineForClassFields": true,
     "useUnknownInCatchVariables": true
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "functions"],
   "references": [{"path": "./tsconfig.node.json"}]
 }


### PR DESCRIPTION
## Summary

Adds auth foundation for platform migration:

- Cloudflare Pages Functions for Google OAuth start, callback, session check, and logout.
- KV-backed OAuth state and session storage.
- Minimal v1-style account affordance in the existing editor shell.
- Local full-stack auth command via `npm run dev:auth`.

## Configuration

Production remains dashboard-managed in Cloudflare:

- `MY_KV` KV namespace binding.
- `GOOGLE_CLIENT_ID` secret/variable.
- `GOOGLE_CLIENT_SECRET` secret.

Google OAuth redirect URIs should include the production origins:

- `https://karektar.pages.dev/api/auth/callback`
- `https://karektar.newtrino.ink/api/auth/callback`

Local auth uses `http://localhost:8788` with `.dev.vars` and `npm run dev:auth`.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] Sign in with Google under `npm run dev:auth`
- [x] Refresh and confirm session persists
- [x] Log out and confirm session clears
- [x] Confirm unsigned editor still works

## Notes

Sessions use a fixed 7-day expiration: both the HttpOnly cookie `Max-Age` and the KV session TTL are 7 days. Sliding session renewal is intentionally deferred.