### PR TITLE
Add authenticated draft persistence

### DIFF
--- a/functions/api/draft/current.ts
+++ b/functions/api/draft/current.ts
@@ -1,0 +1,73 @@
+import {
+  CONTENT_TYPE,
+  CURRENT_DRAFT_PREFIX,
+  HTTP_STATUS,
+  RESPONSE_MESSAGES,
+} from '../../constants'
+import type {PagesFunctionContext} from '../../types'
+import {normalizeStoredFontDraft} from '../../utils/draft'
+import {authenticateRequest} from '../../utils/session'
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {'Content-Type': CONTENT_TYPE.JSON},
+  })
+
+export const onRequest = async ({request, env}: PagesFunctionContext) => {
+  if (request.method !== 'GET' && request.method !== 'PUT') {
+    return jsonResponse(
+      {error: RESPONSE_MESSAGES.METHOD_NOT_ALLOWED},
+      HTTP_STATUS.METHOD_NOT_ALLOWED,
+    )
+  }
+
+  const session = await authenticateRequest(request, env)
+
+  if (!session) {
+    return jsonResponse(
+      {error: RESPONSE_MESSAGES.NOT_AUTHENTICATED},
+      HTTP_STATUS.UNAUTHORIZED,
+    )
+  }
+
+  const key = `${CURRENT_DRAFT_PREFIX}${session.userId}`
+
+  if (request.method === 'GET') {
+    const storedDraft = await env.MY_KV.get<unknown>(key, 'json')
+    const currentDraft = normalizeStoredFontDraft(storedDraft)
+
+    if (!currentDraft) {
+      return jsonResponse(
+        {error: RESPONSE_MESSAGES.NOT_FOUND},
+        HTTP_STATUS.NOT_FOUND,
+      )
+    }
+
+    return jsonResponse(currentDraft)
+  }
+
+  let payload: unknown
+
+  try {
+    payload = await request.json()
+  } catch {
+    return jsonResponse(
+      {error: RESPONSE_MESSAGES.INVALID_REQUEST},
+      HTTP_STATUS.BAD_REQUEST,
+    )
+  }
+
+  const draft = normalizeStoredFontDraft(payload)
+
+  if (!draft) {
+    return jsonResponse(
+      {error: RESPONSE_MESSAGES.INVALID_DRAFT_PAYLOAD},
+      HTTP_STATUS.BAD_REQUEST,
+    )
+  }
+
+  await env.MY_KV.put(key, JSON.stringify({...draft, updatedAt: Date.now()}))
+
+  return jsonResponse({success: true})
+}

--- a/functions/constants.ts
+++ b/functions/constants.ts
@@ -11,6 +11,7 @@ export const HTTP_STATUS = {
   FOUND: 302,
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
+  NOT_FOUND: 404,
   METHOD_NOT_ALLOWED: 405,
 } as const
 
@@ -19,8 +20,11 @@ export const CONTENT_TYPE = {
 } as const
 
 export const RESPONSE_MESSAGES = {
+  INVALID_DRAFT_PAYLOAD: 'Invalid draft payload',
+  INVALID_REQUEST: 'Invalid request',
   METHOD_NOT_ALLOWED: 'Method not allowed',
   NOT_AUTHENTICATED: 'Not authenticated',
+  NOT_FOUND: 'Not found',
 } as const
 
 export const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
@@ -29,6 +33,7 @@ export const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinf
 
 export const OAUTH_STATE_PREFIX = 'oauth_state:'
 export const SESSION_PREFIX = 'session:'
+export const CURRENT_DRAFT_PREFIX = 'current_draft:'
 
 export const OAUTH_STATE_TTL_SECONDS = 60 * 5
 export const SESSION_EXPIRY_DAYS = 7

--- a/functions/utils/draft.ts
+++ b/functions/utils/draft.ts
@@ -1,0 +1,74 @@
+export type StoredFontDraft = {
+  version: 1
+  bitmapSize: number
+  activeGlyph: string
+  glyphs: Record<string, boolean[]>
+  inputText: string
+  symbolSet: string[]
+  updatedAt: number
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every(item => typeof item === 'string')
+
+const isTimestamp = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0
+
+const isGlyph = (value: unknown, bitmapSize: number): value is boolean[] =>
+  Array.isArray(value) &&
+  value.length === bitmapSize ** 2 &&
+  value.every(item => typeof item === 'boolean')
+
+export const normalizeStoredFontDraft = (
+  value: unknown,
+): StoredFontDraft | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  if (
+    value.version !== 1 ||
+    typeof value.bitmapSize !== 'number' ||
+    !Number.isInteger(value.bitmapSize) ||
+    value.bitmapSize <= 0 ||
+    typeof value.activeGlyph !== 'string' ||
+    typeof value.inputText !== 'string' ||
+    !isStringArray(value.symbolSet) ||
+    !isTimestamp(value.updatedAt) ||
+    !isRecord(value.glyphs)
+  ) {
+    return null
+  }
+
+  if (
+    value.symbolSet.length === 0 ||
+    !value.symbolSet.includes(value.activeGlyph)
+  ) {
+    return null
+  }
+
+  const glyphs: StoredFontDraft['glyphs'] = {}
+
+  for (const symbol of value.symbolSet) {
+    const glyph = value.glyphs[symbol]
+
+    if (!isGlyph(glyph, value.bitmapSize)) {
+      return null
+    }
+
+    glyphs[symbol] = [...glyph]
+  }
+
+  return {
+    version: 1,
+    bitmapSize: value.bitmapSize,
+    activeGlyph: value.activeGlyph,
+    glyphs,
+    inputText: value.inputText,
+    symbolSet: [...value.symbolSet],
+    updatedAt: value.updatedAt,
+  }
+}

--- a/src/components/App/App.module.scss
+++ b/src/components/App/App.module.scss
@@ -15,10 +15,16 @@
 }
 
 .accountText,
-.accountError {
+.accountStatus {
   margin: 0;
   font-size: 13px;
   text-align: right;
+}
+
+.accountStatus {
+  min-height: 16px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .accountError {
@@ -29,6 +35,13 @@
   min-width: 84px;
   width: auto;
   padding: 0 12px;
+}
+
+.accountButtonRow {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-end;
+  gap: 6px;
 }
 
 .appRow {
@@ -105,8 +118,12 @@
   }
 
   .accountText,
-  .accountError {
+  .accountStatus {
     text-align: left;
+  }
+
+  .accountButtonRow {
+    justify-content: flex-start;
   }
 
   .appRow {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames'
 import opentype from 'opentype.js'
-import {useEffect, useReducer, useState} from 'react'
+import {useEffect, useReducer, useRef, useState} from 'react'
 import Modal from 'react-modal'
 import {useMediaQuery} from 'react-responsive'
 import styles from './App.module.scss'
@@ -55,6 +55,9 @@ const hasLocalEditorWork = ({
   symbolSet.some((symbol, index) => symbol !== DEFAULT_SYMBOL_SET[index]) ||
   [...glyphSet.values()].some(glyph => !isEmptyGlyph(glyph))
 
+const hasDraftableGlyphSet = ({symbolSet}: TFontProps['fontState']) =>
+  symbolSet.length > 0
+
 const App = ({bitmapSize}: {bitmapSize: number}) => {
   Modal.setAppElement('#root')
   const screenFlag = useMediaQuery({query: `(max-width: ${XS_SCREEN}px)`})
@@ -73,6 +76,8 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
       screenFlag,
     ),
   )
+  const latestFontStateRef = useRef(fontState)
+  latestFontStateRef.current = fontState
 
   const fontProps = {
     fontState: fontState,
@@ -154,19 +159,21 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
         return
       }
 
-      if (areFontDraftsEqual(result.draft, serializeFontDraft(fontState))) {
+      const latestFontState = latestFontStateRef.current
+
+      if (areFontDraftsEqual(result.draft, serializeFontDraft(latestFontState))) {
         setDraftStatus(options?.silent ? null : 'Draft already loaded')
         return
       }
 
-      if (options?.deferIfLocalWork && hasLocalEditorWork(fontState)) {
+      if (options?.deferIfLocalWork && hasLocalEditorWork(latestFontState)) {
         setDraftStatus('Signed in. Load Draft will replace local work.')
         return
       }
 
       if (
         options?.confirmReplace &&
-        hasLocalEditorWork(fontState) &&
+        hasLocalEditorWork(latestFontState) &&
         !window.confirm('Load your saved draft? This will replace local work.')
       ) {
         setDraftStatus('Draft load canceled')
@@ -187,6 +194,11 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
   }
 
   const handleSaveDraft = async () => {
+    if (!hasDraftableGlyphSet(fontState)) {
+      setDraftStatus('No glyphs to save')
+      return
+    }
+
     setDraftLoading(true)
     setDraftStatus('Saving draft...')
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -11,6 +11,12 @@ import {
   checkAuth,
   logout as logoutAuth,
 } from '../../services/auth'
+import {
+  areFontDraftsEqual,
+  loadCurrentDraft,
+  saveCurrentDraft,
+  serializeFontDraft,
+} from '../../services/draft'
 import {TConfirmModal, TFontProps} from '../../types'
 import {
   DEFAULT_FONT_NAME,
@@ -37,6 +43,17 @@ import ConfirmModal from '../ConfirmModal/ConfirmModal'
 import GlyphSet from '../GlyphSet/GlyphSet'
 
 const XS_SCREEN = 576
+const DEFAULT_SYMBOL_SET = getUniqueCharacters(DEFAULT_PROMPT)
+
+const hasLocalEditorWork = ({
+  glyphSet,
+  inputText,
+  symbolSet,
+}: TFontProps['fontState']) =>
+  inputText !== DEFAULT_PROMPT ||
+  symbolSet.length !== DEFAULT_SYMBOL_SET.length ||
+  symbolSet.some((symbol, index) => symbol !== DEFAULT_SYMBOL_SET[index]) ||
+  [...glyphSet.values()].some(glyph => !isEmptyGlyph(glyph))
 
 const App = ({bitmapSize}: {bitmapSize: number}) => {
   Modal.setAppElement('#root')
@@ -68,6 +85,8 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
   const [authUser, setAuthUser] = useState<AuthUser | null>(null)
   const [authLoading, setAuthLoading] = useState(true)
   const [authError, setAuthError] = useState<string | null>(null)
+  const [draftStatus, setDraftStatus] = useState<string | null>(null)
+  const [draftLoading, setDraftLoading] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -83,7 +102,7 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
       } catch {
         if (!cancelled) {
           setAuthUser(null)
-          setAuthError(null)
+          setAuthError('Session check failed. Using local draft mode.')
         }
       } finally {
         if (!cancelled) {
@@ -113,6 +132,91 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
     }
   }
 
+  const handleLoadDraft = async (options?: {
+    confirmReplace?: boolean
+    deferIfLocalWork?: boolean
+    silent?: boolean
+  }) => {
+    setDraftLoading(true)
+    setDraftStatus(options?.silent ? null : 'Loading draft...')
+
+    try {
+      const result = await loadCurrentDraft()
+
+      if (result.status === 'unauthorized') {
+        setAuthUser(null)
+        setDraftStatus('Sign in to load a draft')
+        return
+      }
+
+      if (result.status === 'empty') {
+        setDraftStatus(options?.silent ? null : 'No saved draft yet')
+        return
+      }
+
+      if (areFontDraftsEqual(result.draft, serializeFontDraft(fontState))) {
+        setDraftStatus(options?.silent ? null : 'Draft already loaded')
+        return
+      }
+
+      if (options?.deferIfLocalWork && hasLocalEditorWork(fontState)) {
+        setDraftStatus('Signed in. Load Draft will replace local work.')
+        return
+      }
+
+      if (
+        options?.confirmReplace &&
+        hasLocalEditorWork(fontState) &&
+        !window.confirm('Load your saved draft? This will replace local work.')
+      ) {
+        setDraftStatus('Draft load canceled')
+        return
+      }
+
+      fontDispatch({
+        type: 'GLYPH_SET_ACTION',
+        op: 'LOAD_DRAFT',
+        draft: result.draft,
+      })
+      setDraftStatus(options?.silent ? null : 'Draft loaded')
+    } catch {
+      setDraftStatus('Draft load failed')
+    } finally {
+      setDraftLoading(false)
+    }
+  }
+
+  const handleSaveDraft = async () => {
+    setDraftLoading(true)
+    setDraftStatus('Saving draft...')
+
+    try {
+      const result = await saveCurrentDraft(fontState)
+
+      if (result.status === 'unauthorized') {
+        setAuthUser(null)
+        setDraftStatus('Sign in to save a draft')
+        return
+      }
+
+      setDraftStatus('Draft saved')
+    } catch {
+      setDraftStatus('Draft save failed')
+    } finally {
+      setDraftLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!authUser) {
+      return
+    }
+
+    void handleLoadDraft({deferIfLocalWork: true, silent: true})
+    // Load only when the authenticated account changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authUser?.email])
+
   return (
     <div
       className={classnames(
@@ -129,9 +233,13 @@ const App = ({bitmapSize}: {bitmapSize: number}) => {
           <AccountMenu
             authError={authError}
             authLoading={authLoading}
+            draftLoading={draftLoading}
+            draftStatus={draftStatus}
             user={authUser}
+            onLoadDraft={() => handleLoadDraft({confirmReplace: true})}
             onLogin={beginGoogleLogin}
             onLogout={handleLogout}
+            onSaveDraft={handleSaveDraft}
           />
         </div>
         {!screenFlag && (
@@ -196,17 +304,25 @@ const Title = () => (
 type AccountMenuProps = {
   authError: string | null
   authLoading: boolean
+  draftLoading: boolean
+  draftStatus: string | null
   user: AuthUser | null
+  onLoadDraft: () => Promise<void>
   onLogin: () => void
   onLogout: () => Promise<void>
+  onSaveDraft: () => Promise<void>
 }
 
 const AccountMenu: React.FC<AccountMenuProps> = ({
   authError,
   authLoading,
+  draftLoading,
+  draftStatus,
   user,
+  onLoadDraft,
   onLogin,
   onLogout,
+  onSaveDraft,
 }) => (
   <div className={styles.accountMenu}>
     <p className={styles.accountText}>
@@ -216,15 +332,30 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
           ? `${user.name} (${user.email})`
           : 'Local draft mode'}
     </p>
-    {authError && <p className={styles.accountError}>{authError}</p>}
     {user ? (
-      <button
-        className={styles.accountButton}
-        disabled={authLoading}
-        onClick={() => void onLogout()}
-      >
-        Logout
-      </button>
+      <div className={styles.accountButtonRow}>
+        <button
+          className={styles.accountButton}
+          disabled={authLoading || draftLoading}
+          onClick={() => void onSaveDraft()}
+        >
+          Save Draft
+        </button>
+        <button
+          className={styles.accountButton}
+          disabled={authLoading || draftLoading}
+          onClick={() => void onLoadDraft()}
+        >
+          Load Draft
+        </button>
+        <button
+          className={styles.accountButton}
+          disabled={authLoading}
+          onClick={() => void onLogout()}
+        >
+          Logout
+        </button>
+      </div>
     ) : (
       <button
         className={styles.accountButton}
@@ -234,6 +365,9 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
         Sign In
       </button>
     )}
+    <p className={classnames(styles.accountStatus, authError && styles.accountError)}>
+      {authError ?? draftStatus ?? '\u00a0'}
+    </p>
   </div>
 )
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -16,6 +16,16 @@ export const checkAuth = async () => {
     throw new Error('Failed to check session')
   }
 
+  const contentType = response.headers.get('Content-Type') ?? ''
+
+  if (!contentType.includes('application/json')) {
+    if (import.meta.env.DEV) {
+      return null
+    }
+
+    throw new Error('Invalid session response')
+  }
+
   return (await response.json()) as AuthUser
 }
 

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -1,0 +1,131 @@
+import type {TFont, TSerializedFontDraft} from '../types'
+
+const JSON_HEADERS = {'Content-Type': 'application/json'}
+
+type DraftResult =
+  | {status: 'ok'; draft: TSerializedFontDraft}
+  | {status: 'empty'}
+  | {status: 'unauthorized'}
+
+type SaveDraftResult = {status: 'ok'} | {status: 'unauthorized'}
+
+const isBooleanArray = (value: unknown): value is boolean[] =>
+  Array.isArray(value) && value.every(item => typeof item === 'boolean')
+
+const isSerializedFontDraft = (value: unknown): value is TSerializedFontDraft => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const record = value as Record<string, unknown>
+
+  if (
+    record.version !== 1 ||
+    typeof record.bitmapSize !== 'number' ||
+    typeof record.activeGlyph !== 'string' ||
+    typeof record.inputText !== 'string' ||
+    !Array.isArray(record.symbolSet) ||
+    !record.symbolSet.every(symbol => typeof symbol === 'string') ||
+    typeof record.glyphs !== 'object' ||
+    record.glyphs === null ||
+    Array.isArray(record.glyphs) ||
+    typeof record.updatedAt !== 'number'
+  ) {
+    return false
+  }
+
+  return Object.values(record.glyphs).every(isBooleanArray)
+}
+
+export const serializeFontDraft = (fontState: TFont): TSerializedFontDraft => {
+  const glyphs: TSerializedFontDraft['glyphs'] = {}
+
+  fontState.symbolSet.forEach(symbol => {
+    glyphs[symbol] = [...(fontState.glyphSet.get(symbol) ?? [])]
+  })
+
+  return {
+    version: 1,
+    bitmapSize: fontState.bitmapSize,
+    activeGlyph: fontState.activeGlyph,
+    glyphs,
+    inputText: fontState.inputText,
+    symbolSet: [...fontState.symbolSet],
+    updatedAt: Date.now(),
+  }
+}
+
+export const areFontDraftsEqual = (
+  left: TSerializedFontDraft,
+  right: TSerializedFontDraft,
+) => {
+  if (
+    left.version !== right.version ||
+    left.bitmapSize !== right.bitmapSize ||
+    left.activeGlyph !== right.activeGlyph ||
+    left.inputText !== right.inputText ||
+    left.symbolSet.length !== right.symbolSet.length ||
+    left.symbolSet.some((symbol, index) => symbol !== right.symbolSet[index])
+  ) {
+    return false
+  }
+
+  return left.symbolSet.every(symbol => {
+    const leftGlyph = left.glyphs[symbol]
+    const rightGlyph = right.glyphs[symbol]
+
+    return (
+      leftGlyph !== undefined &&
+      rightGlyph !== undefined &&
+      leftGlyph.length === rightGlyph.length &&
+      leftGlyph.every((cell, index) => cell === rightGlyph[index])
+    )
+  })
+}
+
+export const loadCurrentDraft = async (): Promise<DraftResult> => {
+  const response = await fetch('/api/draft/current', {
+    credentials: 'include',
+  })
+
+  if (response.status === 401) {
+    return {status: 'unauthorized'}
+  }
+
+  if (response.status === 404) {
+    return {status: 'empty'}
+  }
+
+  if (!response.ok) {
+    throw new Error('Failed to load draft')
+  }
+
+  const draft = (await response.json()) as unknown
+
+  if (!isSerializedFontDraft(draft)) {
+    throw new Error('Invalid draft response')
+  }
+
+  return {status: 'ok', draft}
+}
+
+export const saveCurrentDraft = async (
+  fontState: TFont,
+): Promise<SaveDraftResult> => {
+  const response = await fetch('/api/draft/current', {
+    method: 'PUT',
+    credentials: 'include',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(serializeFontDraft(fontState)),
+  })
+
+  if (response.status === 401) {
+    return {status: 'unauthorized'}
+  }
+
+  if (!response.ok) {
+    throw new Error('Failed to save draft')
+  }
+
+  return {status: 'ok'}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,16 @@ export type TFont = {
   vlinePos: number
 }
 
+export type TSerializedFontDraft = {
+  version: 1
+  bitmapSize: number
+  activeGlyph: string
+  glyphs: Record<string, boolean[]>
+  inputText: string
+  symbolSet: string[]
+  updatedAt: number
+}
+
 export type TCanvasAction = {type: 'CANVAS_ACTION'} & (
   | {op: 'UPDATE_ACTIVE_MENU'; newActiveMenu: TMenuLabel | undefined}
   | {op: 'UPDATE_CANVAS_HISTORY'; newGlyphCanvas: boolean[]}
@@ -76,6 +86,7 @@ export type TCanvasAction = {type: 'CANVAS_ACTION'} & (
   | {op: 'REDO'}
 )
 export type TGlyphSetAction = {type: 'GLYPH_SET_ACTION'} & (
+  | {op: 'LOAD_DRAFT'; draft: TSerializedFontDraft}
   | {op: 'RESET_GLYPH_SET'}
   | {op: 'UPDATE_ACTIVE_GLYPH'; newActiveGlyph: string}
   | {op: 'UPDATE_CONFIRM_MODAL'; newConfirmModal: TConfirmModal | undefined}

--- a/src/utils/reducers/fontReducer.ts
+++ b/src/utils/reducers/fontReducer.ts
@@ -25,6 +25,31 @@ export const fontReducer = (state: TFont, action: TFontAction): TFont => {
 
 export const glyphSetReducer = (state: TFont, action: TGlyphSetAction): TFont => {
   switch (action.op) {
+    case 'LOAD_DRAFT': {
+      const {draft} = action
+
+      if (draft.bitmapSize !== state.bitmapSize) {
+        return state
+      }
+
+      const glyphSet: TGlyphSet = new Map<TSymbol, TGlyph>()
+      draft.symbolSet.forEach(symbol => glyphSet.set(symbol, draft.glyphs[symbol]))
+
+      const activeGlyph = draft.symbolSet.includes(draft.activeGlyph)
+        ? draft.activeGlyph
+        : draft.symbolSet[0]
+      const activeCanvas = glyphSet.get(activeGlyph) ?? initializeGlyph(state.bitmapSize)
+
+      return {
+        ...state,
+        activeGlyph,
+        canvasHistory: [activeCanvas],
+        glyphSet,
+        historyIndex: 0,
+        inputText: draft.inputText,
+        symbolSet: draft.symbolSet,
+      }
+    }
     case 'UPDATE_ACTIVE_GLYPH': {
       if (state.activeGlyph === action.newActiveGlyph) {
         return state


### PR DESCRIPTION
## Summary

- Add an authenticated `/api/draft/current` Pages Function backed by user-scoped KV.
- Persist one current draft per signed-in user.
- Serialize and hydrate the existing reducer-driven editor state instead of introducing a new frontend state model.
- Add `Save Draft` / `Load Draft` controls to the account menu.
- Preserve signed-out local editor behavior.
- Guard draft loading from silently overwriting local work.
- Skip no-op draft loads and handle empty draft saves with clearer feedback.

## Implementation Notes

- Drafts are stored in KV under the authenticated user id.
- The persisted draft includes the current reducer editor state: `inputText`, `symbolSet`, `glyphs`, `activeGlyph`, `bitmapSize`, and `updatedAt`.
- Loading a draft dispatches a reducer action so the reducer remains the editor source of truth.
- Plain Vite local development treats the missing auth endpoint as signed-out mode instead of showing a false session error.
- Auto-load uses the latest reducer state before applying a draft to avoid overwriting edits made while the load request is in flight.

## Validation

Automated checks:
- `npm run build`
- `npm run lint`

Manual validation:
- Signed-out editor still works.
- Sign in with Google.
- Edit the current canvas.
- Save the account draft.
- Refresh and confirm the draft restores.
- Log out and confirm local in-session editor state is not destroyed.
- Sign back in and confirm the account draft can load again.