### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- Describe the user-visible or developer-facing changes in 2-4 bullets. -->
+- `<change>`
+
+## Why
+
+<!-- Explain the problem this solves, the workflow it improves, or the migration phase it supports. -->
+
+## Implementation Notes
+
+<!-- Capture notable architecture, data-flow, migration, or implementation decisions. -->
+- `<implementation detail>`
+
+## Configuration / Runtime Notes
+
+<!-- List environment variables, Cloudflare settings, OAuth redirects, commands, or deployment assumptions. -->
+- No configuration changes.
+
+## Out of Scope
+
+<!-- Remove this section if it is not relevant. Use it when the PR intentionally defers adjacent work or is part of a staged migration. -->
+- `<deferred or excluded work>`
+
+## Validation
+
+Automated checks:
+- [ ] `npm run build`
+- [ ] `npm run lint`
+
+Manual validation:
+- [ ] `<manual scenario>`
+
+## Notes
+
+<!-- Optional. Use for tradeoffs, follow-up PRs, or links to related issues. Remove if not needed. -->


### PR DESCRIPTION
## Summary

- Add a reusable GitHub pull request template.
- Standardize future PR descriptions around summary, rationale, implementation notes, runtime/config notes, validation, and optional follow-up context.
- Keep `Out of Scope` available for staged migration work without making it mandatory for every small change.

## Why

Recent platform migration work needs clearer PR boundaries, especially when stacked branches target staging branches before `main`. Older PRs were mostly narrative, while the newer auth PR used a more useful structured format. This template coalesces those patterns into a consistent default for future work.

## Implementation Notes

- Adds `.github/pull_request_template.md`.
- Uses HTML comments for guidance so placeholder instructions do not render in submitted PR descriptions.
- Keeps validation split between automated checks and manual validation.
- Marks `Out of Scope` and `Notes` as removable when they are not relevant.

## Configuration / Runtime Notes

- No configuration changes.

## Out of Scope

- This does not add issue templates.
- This does not change CI or branch protection.
- This does not update existing PR descriptions.

## Validation

Automated checks:
- [ ] Not run; Markdown-only template change.

Manual validation:
- [x] Confirmed the branch diff contains only `.github/pull_request_template.md`.
- [x] Reviewed the template sections against recent Karektar PR patterns.